### PR TITLE
recursively scan subdirectories

### DIFF
--- a/src/main/java/jdk/JsplitpgkscanTask.java
+++ b/src/main/java/jdk/JsplitpgkscanTask.java
@@ -192,7 +192,7 @@ class JsplitpgkscanTask {
                     if (argIt.hasNext()) {
                         Path libraryDirectory = Paths.get(argIt.next());
                         if (Files.isDirectory(libraryDirectory)) {
-                            try (Stream<Path> list = Files.list(libraryDirectory)) {
+                            try (Stream<Path> list = Files.walk(libraryDirectory)) {
                                 list.forEach(this::addAnalyzer);
                                 continue;
                             } catch (IOException ioe) {

--- a/src/main/resources/jdk/resources/jsplitpkgscan.properties
+++ b/src/main/resources/jdk/resources/jsplitpkgscan.properties
@@ -12,6 +12,7 @@ Usage: {0} <options> <path ...>]\n\
 \                                file or exploded directory\n\
 \  -d <directory>                Directory containing JAR/RAR/WAR files or\n\
 \                                exploded directories to scan\n\
+\                                (scans subdirectories as well)\n\
 \  -f <file>                     File containing a list of JAR/RAR/WAR files\n\
 \                                or exploded directories to scan\n\
 \  -p <package prefix>           Package prefix to report only split packages\n\


### PR DESCRIPTION
The `-d` option now scans subdirectories as well, recursively.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/adoptopenjdk/jsplitpkgscan/7)
<!-- Reviewable:end -->
