### PR TITLE
Shortens file uri, adds handling of exploded jar/war/rar

### DIFF
--- a/src/main/java/jdk/JsplitpgkscanTask.java
+++ b/src/main/java/jdk/JsplitpgkscanTask.java
@@ -219,7 +219,6 @@ class JsplitpgkscanTask {
                                 ioe.printStackTrace(log);
                                 throw new BadArgs("err.scanning.dir", libraryDirectory);
                             }
-
                         }
                         throw new BadArgs("err.invalid.path", libraryDirectory);
                     }


### PR DESCRIPTION
Output has now relativized file URI output. Adds support for exploded JAR/RAR/WAR files as supported in a WildFly deployment directory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/adoptopenjdk/jsplitpkgscan/11)
<!-- Reviewable:end -->
