### PR TITLE
Add package entries count to each split package

### DIFF
--- a/src/main/java/jdk/JsplitpgkscanTask.java
+++ b/src/main/java/jdk/JsplitpgkscanTask.java
@@ -235,7 +235,7 @@ class JsplitpgkscanTask {
         Map<String, Library> packageToModule = Library.packageToModule();
         Map<String, List<Library>> packages = new HashMap<>();
         for (Library analyzer : options.libraries) {
-            analyzer.packages().stream()
+            analyzer.packages().keySet().stream()
                     .forEach(packageName -> {
                         List<Library> values =
                                 packages.computeIfAbsent(packageName, key -> new ArrayList<>());
@@ -263,10 +263,9 @@ class JsplitpgkscanTask {
             splitPkgs.forEach(element -> {
                 log.println(element.getKey()); // the package name
                 element.getValue().stream()
-                        .map(Library::location)
                         .distinct()
                         .sorted()
-                        .forEach(location -> log.format("    %s%n", location));
+                        .forEach(library -> log.format("  %5d  %s%n", library.count(element.getKey()), library.location()));
             });
         }
     }
@@ -274,7 +273,7 @@ class JsplitpgkscanTask {
     private void reportAllPackages(Map<String, List<Library>> packages) {
         log.println("- All packages:");
         for (Library analyzer : options.libraries) {
-            List<String> allPkgs = analyzer.packages()
+            List<String> allPkgs = analyzer.packages().keySet()
                     .stream()
                     .filter(element -> element.startsWith(options.packageArg))
                     .sorted()

--- a/src/main/java/jdk/Library.java
+++ b/src/main/java/jdk/Library.java
@@ -126,7 +126,7 @@ class Library implements Comparable<Library>{
                     .map(Path::getParent)
                     .map(dir::relativize)
                     .map(Path::toString)
-                    .map(pathName -> pathName.replace(File.separator, "."))
+                    .map(pathName -> pathName.replace(File.separatorChar, '.'))
                     .map(Library::specialCaseTranslator)
                     .sorted()
                     .collect(Collectors.groupingBy(pkg -> pkg, Collectors.counting()));

--- a/src/main/java/jdk/Library.java
+++ b/src/main/java/jdk/Library.java
@@ -46,7 +46,7 @@ import java.util.stream.Collectors;
  */
 class Library implements Comparable<Library>{
     private static final String MODULE_INFO = "module-info.class";
-    public static final Long ZERO = Long.valueOf(0);
+    private static final Long ZERO = Long.valueOf(0); // marks count inside a module, where we do not know the number of classes
 
     private final URI location;
     private final Map<String, Long> packages;
@@ -79,7 +79,14 @@ class Library implements Comparable<Library>{
         return location;
     }
 
-
+    /**
+     * Returns the number of classes in a given package.
+     * <p>
+     * If the library represents a module, the number is unknown and {@code 0} is returned.
+     *
+     * @param packageName the full name of the package
+     * @return the number of classes in package {@code packageName}
+     */
     Long count(String packageName){
         return packages.get(packageName);
     }
@@ -98,6 +105,11 @@ class Library implements Comparable<Library>{
         }
         Library other = (Library)obj;
         return compareTo(other) == 0;
+    }
+
+    @Override
+    public int compareTo(Library other) {
+        return location.compareTo(other.location);
     }
 
     /**
@@ -144,7 +156,7 @@ class Library implements Comparable<Library>{
         Map<String, Library> map = new HashMap<>();
         ModuleFinder.ofSystem().findAll()
                 .stream()
-                .map(moduleReference -> new Library(moduleReference))
+                .map(Library::new)
                 .forEach(library -> library.packages().forEach((packageName, count) -> map.put(packageName, library)));
         return map;
     }
@@ -159,10 +171,5 @@ class Library implements Comparable<Library>{
             return packageName.substring(16);
         }
         return packageName;
-    }
-
-    @Override
-    public int compareTo(Library o) {
-        return location.compareTo(o.location);
     }
 }


### PR DESCRIPTION
Adds the number of classes inside a given package to the split package output.

Fixes #5.

You probably want to merge this squashed - I had some trouble merging from master ...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/adoptopenjdk/jsplitpkgscan/12)
<!-- Reviewable:end -->
