### PR TITLE
Fix library relative path generation on Windows

### DIFF
--- a/src/main/java/jdk/Library.java
+++ b/src/main/java/jdk/Library.java
@@ -52,7 +52,8 @@ class Library implements Comparable<Library>{
     private final Map<String, Long> packages;
 
     Library(Path path, Function<Path, Path> relativizeFunction, Function<Path, Map<String, Long>> pkgFunction) throws IOException {
-        this.location = URI.create("file:/" + relativizeFunction.apply(path));
+        String relativePath = relativizeFunction.apply(path).toString().replace("\\", "/");
+        this.location = URI.create("file:/" + relativePath);
         this.packages = pkgFunction.apply(path);
     }
 


### PR DESCRIPTION
This allow tool to run on Windows.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/adoptopenjdk/jsplitpkgscan/14)
<!-- Reviewable:end -->
